### PR TITLE
Update travis to use PHP 5.6 required by BLT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
     - "$HOME/.drush/cache"
     - "$HOME/.npm"
 php:
-  - 5.5
+  - 5.6
 
 sudo: false
 


### PR DESCRIPTION
```
Problem 1
    - Installation request for acquia/blt 8.x-dev -> satisfiable by acquia/blt[8.x-dev].
    - acquia/blt 8.x-dev requires php >=5.6 -> your PHP version (5.5.21) does not satisfy that requirement.
```