### PR TITLE
Fix issues surfaced by CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ install:
   # Add Composer's local bin directory to the PATH so that we will be running
   # our installed versions of Drush, PHPCS, Behat, PhantomJS, etc.
   - export PATH="$HOME/.composer/vendor/bin:$TRAVIS_BUILD_DIR/bin:$PATH"
+  
+  # Speed up Composer operations.
+  - composer global require "hirak/prestissimo:^0.3"
 
   # MySQL Options
   - mysql -e 'SET GLOBAL wait_timeout = 5400;'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
     - "$HOME/.drush/cache"
     - "$HOME/.npm"
 php:
-  - 5.5
+  - 5.6
 
 sudo: false
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
     "require-dev": {},
     "scripts": {
       "post-create-project-cmd": [
-        "git init",
         "blt internal:create-project:init-repo"
       ]
     }


### PR DESCRIPTION
## Suggested Changes

Address the following problems, surfaced by the CI testing:

**Problem 1**
- Installation request for `acquia/blt 8.x-dev` -> satisfiable by `acquia/blt[8.x-dev]`.
- `acquia/blt 8.x-dev` requires `php >=5.6` -> your PHP version (5.5.21) does not satisfy that requirement.

**Problem 2**
- Script blt internal:create-project:init-repo handling the post-create-project-cmd event returned with error code 1. Could not initialize new git repository. 

```
> git init
Initialized empty Git repository in /home/travis/build/acquia/blt-example/.git/
> blt internal:create-project:init-repo
[ExecStack] git init && git add -A && git commit -m 'Initial commit.'
[ExecStack]  Reinitialized existing Git repository in /home/travis/build/acquia/blt-example/.git/ 
[ExecStack]  Exit code 128 
[error]  Could not initialize new git repository. 
Script blt internal:create-project:init-repo handling the post-create-project-cmd event returned with error code 1
```

