### PR TITLE
Revert "BLT already inits repo."

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,5 +7,10 @@
     "require": {
         "acquia/blt": "9.1.x-dev"
     },
-    "require-dev": {}
+    "require-dev": {},
+    "scripts": {
+      "post-create-project-cmd": [
+        "blt internal:create-project:init-repo"
+      ]
+    }
 }


### PR DESCRIPTION
Reverts acquia/blt-project#19

Now I understand what's going on here... when `composer create-project` clones a base project from source, that includes a VCS directory, so after the project has finished installing Composer removes that VCS directory.

This means that anything BLT does to the VCS dir during the install process (such as `internal:create-project:init-repo`) will get clobbered when Composer cleans up. I'm not sure how to work around this other than to have a post-create-project command that re-runs `internal:create-project:init-repo`.