### PR TITLE
Update memcache and use acquia recommended RTBC patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "drupal/core": "^8.6.0",
         "drupal/devel": "^2.0.0",
         "drupal/features": "^3.8.0",
-        "drupal/memcache": "2.0-alpha7",
+        "drupal/memcache": "^2.0",
         "drupal/qa_accounts": "^1.0.0-alpha1",
         "drupal/seckit": "^1.0.0-alpha2",
         "drupal/shield": "^1.2.0"
@@ -73,7 +73,11 @@
         "patchLevel": {
             "drupal/core": "-p2"
         },
-        "patches": []
+        "patches": {
+            "drupal/memcache": {
+                "12987574 - >1M data writes incompatible with memcached (memcached -I 32M -m32): #435694": "https://www.drupal.org/files/issues/2019-02-26/435694-118-d8-memcache-large-items.patch"
+            }
+        }
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR updates the memcache module to the latest stable release and patches the memcache module to use the finally RTBC (but not yet merged) patch for large objects (see https://www.drupal.org/project/memcache/issues/435694). We/Acquia unfortunately have not yet been successful in getting this critical patch merged by the maintainers (@pat-patterson-acq can provide more background information internally if needed).

After several months of collaboration between product / engineering / CS this change will be required to finally update the BLT memcache settings at https://github.com/acquia/blt/blob/10.x/settings/memcache.settings.php to what is the "new" Acquia supported memcache recommendation that will be in docs. (PR to BLT with the new recommended settings is forthcoming)